### PR TITLE
remove need for `load_constant` function

### DIFF
--- a/src/chips/hash_1.rs
+++ b/src/chips/hash_1.rs
@@ -63,24 +63,6 @@ impl<F: FieldExt> Hash1Chip<F> {
         )
     }
 
-    pub fn load_constant(
-        &self,
-        mut layouter: impl Layouter<F>,
-        constant: F,
-    ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
-            || "load constant",
-            |mut region| {
-                region.assign_advice_from_constant(
-                    || "constant value",
-                    self.config.advice[0],
-                    0,
-                    constant,
-                )
-            },
-        )
-    }
-
     pub fn expose_public(
         &self,
         mut layouter: impl Layouter<F>,

--- a/src/chips/merkle_v1.rs
+++ b/src/chips/merkle_v1.rs
@@ -36,7 +36,6 @@ impl<F: FieldExt> MerkleTreeV1Chip<F> {
         let swap_selector = meta.selector();
         let hash_selector = meta.selector();
         meta.enable_equality(col_a);
-        meta.enable_equality(col_b);
         meta.enable_equality(col_c);
         meta.enable_equality(instance);
 

--- a/src/chips/merkle_v2.rs
+++ b/src/chips/merkle_v2.rs
@@ -89,24 +89,6 @@ impl<F: FieldExt> MerkleTreeV2Chip<F> {
         )
     }
 
-    pub fn load_constant(
-        &self,
-        mut layouter: impl Layouter<F>,
-        constant: F,
-    ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
-            || "load constant",
-            |mut region| {
-                region.assign_advice_from_constant(
-                    || "constant value",
-                    self.config.advice[0],
-                    0,
-                    constant,
-                )
-            },
-        )
-    }
-
     pub fn expose_public(
         &self,
         mut layouter: impl Layouter<F>,


### PR DESCRIPTION
Removed unnecessary function from `hash_1` chip

Removed unnecessary equality enabler on `merkle_v1` chip